### PR TITLE
force set to en for get REVISION

### DIFF
--- a/scripts/info.sh
+++ b/scripts/info.sh
@@ -4,7 +4,7 @@ URL="https://svn.webkit.org/repository/webkit/releases/WebKitGTK/webkit-${npm_pa
 ROOTDIR=$PWD
 
 INFO=$(svn info "${URL}")
-export REVISION=$(svn info "${URL}" | sed -n 's/^Last Changed Rev: //p')
+export REVISION=$(LANG=en svn info "${URL}" | sed -n 's/^Last Changed Rev: //p')
 CONFIG=$(node -e "console.log(require('$ROOTDIR/package.json').config)")
 APPLE_VERSION=$(svn cat "${URL}/Source/WebCore/Configurations/Version.xcconfig" | grep 'MAJOR_VERSION\s=\|MINOR_VERSION\s=\|TINY_VERSION\s=\|MICRO_VERSION\s=\|NANO_VERSION\s=')
 


### PR DESCRIPTION
Some LANG can't get REVISION. such as `ja_JP.UTF-8`

Here is my environment results.

```
% echo $LANG
ja_JP.UTF-8
% npm run info

> @kudo-ci/jsc-android@250230.2.1-debug info /Users/kyosukekameda/repo/src/github.com/Kudo/jsc-android-buildscripts
> ./scripts/info.sh






			Revision: 


Config:
{
  webkitGTK: '2.26.1',
  chromiumICUCommit: '64e5d7d43a1ff205e3787ab6150bbc1a1837332b'
}

Info:
パス: webkit-2.26.1
URL: https://svn.webkit.org/repository/webkit/releases/WebKitGTK/webkit-2.26.1
Relative URL: ^/releases/WebKitGTK/webkit-2.26.1
リポジトリのルート: https://svn.webkit.org/repository/webkit
リポジトリ UUID: 268f45cc-cd09-0410-ab3c-d52691b4dbfc
リビジョン: 262942
ノード種別: ディレクトリ
最終変更者: carlosgc@webkit.org
最終変更リビジョン: 250230
最終変更日時: 2019-09-23 19:42:18 +0900 (2019/09/23 (月))

AppleWebkit:
MAJOR_VERSION = 609;
MINOR_VERSION = 1;
TINY_VERSION = 3;
MICRO_VERSION = 0;
NANO_VERSION = 0;

Size:
0
```

Revision is empty, so fail `createAAR`.